### PR TITLE
Static Local machine support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Remember to start your snowstorm service with read only disabled! [edit in ./doc
     [SHORTNAME] -> SHORTNAME for your codebase, ie. SNOMEDCT
     * For more in-depth explanation of each option, we would like to refer you to the IHTSDO snowstorm GitHub documentation.
 
+
 Appendix A)
 
     To import the Dutch Edition and GMDN/Patient Friendly releases to a fresh database, download the releases to the ./ingest folder, after which the following commands should be sufficient: (as of 7-2019)
@@ -81,3 +82,7 @@ Appendix A)
         docker run --rm -it --mount src=$(pwd),target=/app/,type=bind nictiz/snowstorm-ingest [SERVERURL:PORT] SNAPSHOT "Nictiz-Snowstorm\ingest\SnomedCT_GMDNMapRelease_Production_20190331T120000Z.zip" MAIN SNOMEDCT
 
         docker run --rm -it --mount src=$(pwd),target=/app/,type=bind nictiz/snowstorm-ingest [SERVERURL:PORT] SNAPSHOT "Nictiz-Snowstorm\ingest\SnomedCT_Netherlands_PatientFriendlyExtensionRelease_PRODUCTION_20190331T120000Z.zip" MAIN SNOMEDCT
+    
+    2) Snowstorm container running on the same machine as ingest (i.e. localhost)? Add --network=snowstorm to your docker ingest run command:
+        docker run --network=snowstorm --rm -it --mount src=$(pwd),target=/app/,type=bind nictiz/snowstorm-ingest [SERVERURL:PORT] SNAPSHOT "Nictiz-Snowstorm\ingest\SnomedCT_Netherlands_PatientFriendlyExtensionRelease_PRODUCTION_20190331T120000Z.zip" MAIN SNOMEDCT
+

--- a/README.md
+++ b/README.md
@@ -83,6 +83,6 @@ Appendix A)
 
         docker run --rm -it --mount src=$(pwd),target=/app/,type=bind nictiz/snowstorm-ingest [SERVERURL:PORT] SNAPSHOT "Nictiz-Snowstorm\ingest\SnomedCT_Netherlands_PatientFriendlyExtensionRelease_PRODUCTION_20190331T120000Z.zip" MAIN SNOMEDCT
     
-    2) Snowstorm container running on the same machine as ingest (i.e. localhost)? Add --network=snowstorm to your docker ingest run command:
+    2) If your Snowstorm container is running on the same machine as the ingest (i.e. localhost)? You may have to add --network=snowstorm to your docker ingest run command:
         docker run --network=snowstorm --rm -it --mount src=$(pwd),target=/app/,type=bind nictiz/snowstorm-ingest [SERVERURL:PORT] SNAPSHOT "Nictiz-Snowstorm\ingest\SnomedCT_Netherlands_PatientFriendlyExtensionRelease_PRODUCTION_20190331T120000Z.zip" MAIN SNOMEDCT
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       - ./elastic:/usr/share/elasticsearch/data
     networks:
-      elastic:
+      snowstorm:
         aliases:
          - es
     healthcheck:
@@ -49,7 +49,7 @@ services:
     # >> --snowstorm.rest-api.readonly=false
     entrypoint: java -Xms2g -Xmx4g -jar snowstorm.jar --elasticsearch.urls=http://es:9200 --snowstorm.rest-api.readonly=false
     networks:
-      elastic:
+      snowstorm:
         aliases:
           - snow
     healthcheck:
@@ -61,4 +61,8 @@ services:
       - 8080:8080
 
 networks:
-  elastic:
+  snowstorm:
+    name: snowstorm
+
+volumes:
+  elastic_data:

--- a/ingest/ingest.py
+++ b/ingest/ingest.py
@@ -140,8 +140,9 @@ def importRelease(branchPath, shortName, fileName, importType, serverUrl):
                         print("For more information, see the log files of the snowstorm process / container")
                         break
                     sleep(10)
-    except:
-        print("Some error has occurred during the import process.")
+    except Exception as e:
+        print("An error has occurred during the import process.")
+        print("Exception: ",e)
         print("Import file:\t", fileName)
 
 # Check for a provided filename and codebase


### PR DESCRIPTION
For some reason (firewall/docker e.g.) the ingest Docker container couldn't reach the http://localhost:8080 snowstorm Docker container on MacOS 10.14.6 while trying to ingest a basic SnomedCT Snapshot.

Troubleshooted by adding "Some error" exception printing. 
Fixed by adding the docker network parameter to the ingest run command and adding static network name to the snowstorm docker.