### PR TITLE
Alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ Appendix A)
 
     docker run --rm -it --network snowstorm_network --mount src=$(pwd),target=/releases/,type=bind nictiz/snowstorm-ingest http://snow:8080 SNAPSHOT "SnomedCT_Netherlands_EditionRelease_PRODUCTION_20190331T120000Z.zip" MAIN SNOMEDCT
 
-    docker run --rm -it --network snowstorm_network --mount src=$(pwd),target=/releases/,type=bind nictiz/snowstorm-ingest http://snow:8080 SNAPSHOT "SnomedCT_GMDNMapRelease_Production_20190331T120000Z.zip" MAIN SNOMEDCT
+    docker run --rm -it --network snowstorm_network --mount src=$(pwd),target=/releases/,type=bind nictiz/snowstorm-ingest http://snow:8080 SNAPSHOT "SnomedCT_GMDNMapRelease_Production_20190331T120000Z.zip" MAIN/SNOMEDCT-GMDN SNOMEDCT-GMDN
 
-    docker run --rm -it --network snowstorm_network --mount src=$(pwd),target=/releases/,type=bind nictiz/snowstorm-ingest http://snow:8080 SNAPSHOT "SnomedCT_Netherlands_PatientFriendlyExtensionRelease_PRODUCTION_20190331T120000Z.zip" MAIN SNOMEDCT
+    docker run --rm -it --network snowstorm_network --mount src=$(pwd),target=/releases/,type=bind nictiz/snowstorm-ingest http://snow:8080 SNAPSHOT "SnomedCT_Netherlands_PatientFriendlyExtensionRelease_PRODUCTION_20190331T120000Z.zip" MAIN/SNOMEDCT-NL-PF SNOMEDCT-NL-PF

--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ Appendix A)
 
     docker run --rm -it --network snowstorm_network --mount src=$(pwd),target=/releases/,type=bind nictiz/snowstorm-ingest http://snow:8080 SNAPSHOT "SnomedCT_Netherlands_EditionRelease_PRODUCTION_20190331T120000Z.zip" MAIN SNOMEDCT
 
-    docker run --rm -it --network snowstorm_network --mount src=$(pwd),target=/releases/,type=bind nictiz/snowstorm-ingest http://snow:8080 SNAPSHOT "SnomedCT_GMDNMapRelease_Production_20190331T120000Z.zip" MAIN/SNOMEDCT-GMDN SNOMEDCT-GMDN
+    docker run --rm -it --network snowstorm_network --mount src=$(pwd),target=/releases/,type=bind nictiz/snowstorm-ingest http://snow:8080 SNAPSHOT "SnomedCT_GMDNMapRelease_Production_20190331T120000Z.zip" MAIN SNOMEDCT
 
-    docker run --rm -it --network snowstorm_network --mount src=$(pwd),target=/releases/,type=bind nictiz/snowstorm-ingest http://snow:8080 SNAPSHOT "SnomedCT_Netherlands_PatientFriendlyExtensionRelease_PRODUCTION_20190331T120000Z.zip" MAIN/SNOMEDCT-NL-PF SNOMEDCT-NL-PF
+    docker run --rm -it --network snowstorm_network --mount src=$(pwd),target=/releases/,type=bind nictiz/snowstorm-ingest http://snow:8080 SNAPSHOT "SnomedCT_Netherlands_PatientFriendlyExtensionRelease_PRODUCTION_20190331T120000Z.zip" MAIN SNOMEDCT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,12 @@ services:
     # Write allowed: (required for creating the database indices)
     #   >> --snowstorm.rest-api.readonly=false
     # Remove --spring.autoconfigure.exclude=org.springframework.cloud.aws.autoconfigure.context.ContextStac when deploying on AWS
-    entrypoint: java -Xms2g -Xmx4g -jar snowstorm.jar --elasticsearch.urls=http://es:9200 --snowstorm.rest-api.readonly=false --spring.autoconfigure.exclude=org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration
+    entrypoint: java -Xms2g -Xmx4g -jar snowstorm.jar
+      --elasticsearch.urls=http://es:9200
+      --snowstorm.rest-api.readonly=false
+      --spring.autoconfigure.exclude=org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration 
+      --spring.servlet.multipart.max-file-size=1000MB
+      --spring.servlet.multipart.max-request-size=1000MB
     networks:
       snowstorm_network:
         aliases:

--- a/snowstorm/Dockerfile-snowstorm
+++ b/snowstorm/Dockerfile-snowstorm
@@ -2,7 +2,7 @@ FROM openjdk:8-jdk-alpine
 LABEL maintainer="Nictiz <info@snomed.nl>, adapted from https://github.com/IHTSDO/snowstorm/ by SNOMED International <tooling@snomed.org>"
 
 # Set snowstorm version
-ARG SNOWSTORM_VERSION=3.0.3
+ARG SNOWSTORM_VERSION=4.1.0
 
 ARG SUID=1042
 ARG SGID=1042

--- a/snowstorm/Dockerfile-snowstorm
+++ b/snowstorm/Dockerfile-snowstorm
@@ -32,4 +32,4 @@ RUN chown -R snowstorm:snowstorm /app
 # Run as the snowstorm user.
 USER snowstorm
 
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","snowstorm.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","snowstorm.jar","spring.servlet.multipart.max-file-size=1000MB","spring.servlet.multipart.max-request-size=1000MB","logging.level.org.springframework=DEBUG"]


### PR DESCRIPTION
Updated maximum file size for the new NL Release, through commandline in compose and dockerfile. This will be included in Snowstorm 4.3.x, but for now this is the only way.
See also; https://github.com/IHTSDO/snowstorm/issues/74